### PR TITLE
Add poller CLI with interval control and usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,19 @@ GPGC is a distributed greenhouse monitoring & control system. Edge devices (Luck
 
 ---
 
-## 5) Repository Layout
+## 5) Poller Usage
+Run the backend poller from the repository root to continuously read sensors:
+
+```bash
+python -m backend.poller --interval 30
+```
+
+`--interval` controls the seconds between polling cycles (default `60`). Logs
+are written to stdout and connection errors are logged before retrying.
+
+---
+
+## 6) Repository Layout
 ```
 repo-root/
 ├─ backend/                # Omni apps, API server, pollers
@@ -68,7 +80,7 @@ repo-root/
 
 ---
 
-## 6) Roadmap (From Project Timeline)
+## 7) Roadmap (From Project Timeline)
 - Phase 1: Sensor setup & connectivity
 - Phase 2: Alert system configuration
 - Phase 3: Manual control implementation
@@ -78,12 +90,12 @@ repo-root/
 
 ---
 
-## 7) Security & Access
+## 8) Security & Access
 - API authentication for web/mobile.
 - SSH key auth for backend hosts.
 - Cloud creds stored only on Omni.
 
 ---
 
-## 8) License & Contact
+## 9) License & Contact
 License: Private (GPGC). Maintainer: <add your name/contact>.


### PR DESCRIPTION
## Summary
- add CLI entrypoint in `backend/poller.py` with argparse interval option and logging to stdout
- handle Modbus connection errors and run continuous polling loop
- document poller usage in README

## Testing
- `pip install pymodbus python-dotenv`
- `python -m backend.poller --interval 0.1`
- `SENSOR1_ADDRESS=1 python -m backend.poller --interval 0.1`


------
https://chatgpt.com/codex/tasks/task_e_689e91054180833280190ae7528cfe55