### PR TITLE
Add environment template and README setup instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Example environment configuration for the RS485 poller
+# Replace the placeholders with values for your setup
+
+# RS485 gateway connection
+RS485_GATEWAY_HOST=192.0.2.1
+RS485_GATEWAY_PORT=502
+
+# Sensor addresses (Modbus slave IDs)
+SENSOR1_ADDRESS=1
+SENSOR2_ADDRESS=2
+# Add more SENSOR<N>_ADDRESS entries as needed

--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
+Copy the example environment file and adjust it for your gateway and sensors:
+
+```bash
+cp .env.example .env
+```
+
 Then run the backend poller from the repository root to continuously read sensors:
 
 ```bash


### PR DESCRIPTION
## Summary
- provide `.env.example` showing RS485 gateway and sensor address variables
- document copying `.env.example` to `.env` in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f3339ccb883329b74b6195acfca85