### PR TITLE
Use RS485 env vars for SHT20 tool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,9 @@
 RS485_GATEWAY_HOST=192.0.2.1
 RS485_GATEWAY_PORT=502
 
+# Example sensor address for diagnostic scripts
+SENSOR_ADDRESS=1
+
 # Sensor addresses (Modbus slave IDs)
 SENSOR1_ADDRESS=1
 SENSOR2_ADDRESS=2

--- a/tools/README.md
+++ b/tools/README.md
@@ -10,4 +10,13 @@ Polls an SHT20 sensor via the Waveshare 4‑channel RS485 gateway.
 ```bash
 python sht20_ch4_test.py [--mode rtu|tcp]
 ```
-Defaults to RTU‑over‑TCP. Override connection details with the `GW_CH4_HOST`, `GW_PORT`, `GW_CH4_SLAVES`, `REG_TEMP`, and `REG_RH` environment variables.
+Defaults to RTU‑over‑TCP. Override connection details with the `RS485_GATEWAY_HOST`, `RS485_GATEWAY_PORT`, `SENSOR_ADDRESS`, `REG_TEMP`, and `REG_RH` environment variables.
+
+Example:
+
+```bash
+export RS485_GATEWAY_HOST=192.168.1.204
+export RS485_GATEWAY_PORT=4196
+export SENSOR_ADDRESS=1
+python sht20_ch4_test.py
+```

--- a/tools/sht20_ch4_test.py
+++ b/tools/sht20_ch4_test.py
@@ -1,9 +1,9 @@
 import argparse, os, sys, time
 from pymodbus.client import ModbusSerialClient, ModbusTcpClient
 
-HOST = os.getenv("GW_CH4_HOST", "192.168.1.204")
-PORT = int(os.getenv("GW_PORT", "4196"))
-SLAVE = int(os.getenv("GW_CH4_SLAVES", "1"))
+HOST = os.getenv("RS485_GATEWAY_HOST", "192.168.1.204")
+PORT = int(os.getenv("RS485_GATEWAY_PORT", "4196"))
+SENSOR_ADDRESS = int(os.getenv("SENSOR_ADDRESS", "1"))
 REG_TEMP = int(os.getenv("REG_TEMP", "0x0001"), 16)
 REG_RH   = int(os.getenv("REG_RH",   "0x0002"), 16)
 
@@ -32,8 +32,8 @@ def main():
         sys.exit(2)
 
     try:
-        t_raw = read_one(client, SLAVE, REG_TEMP)  # °C × 10
-        h_raw = read_one(client, SLAVE, REG_RH)    # %RH × 10
+        t_raw = read_one(client, SENSOR_ADDRESS, REG_TEMP)  # °C × 10
+        h_raw = read_one(client, SENSOR_ADDRESS, REG_RH)    # %RH × 10
         print(f"Temperature: {t_raw/10.0:.1f} °C")
         print(f"Humidity:    {h_raw/10.0:.1f} %RH")
     finally:


### PR DESCRIPTION
## Summary
- use RS485_GATEWAY_HOST/PORT and SENSOR_ADDRESS in SHT20 test script
- document new env vars for diagnostic script
- add example SENSOR_ADDRESS to `.env.example`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f370aecd4833284f85f8c9b2aa7e5