### PR TITLE
Use holding registers for SHT20

### DIFF
--- a/tools/sht20_ch4_test.py
+++ b/tools/sht20_ch4_test.py
@@ -4,12 +4,21 @@ from pymodbus.client import ModbusSerialClient, ModbusTcpClient
 HOST = os.getenv("GW_CH4_HOST", "192.168.1.204")
 PORT = int(os.getenv("GW_PORT", "4196"))
 SLAVE = int(os.getenv("GW_CH4_SLAVES", "1"))
-REG_TEMP = int(os.getenv("REG_TEMP", "0x0001"), 16)
-REG_RH   = int(os.getenv("REG_RH",   "0x0002"), 16)
+# SHT20 sensor exposes temperature and humidity via holding registers.
+REG_TEMP = int(os.getenv("REG_TEMP", "0x0001"), 16)  # Holding register for temperature
+REG_RH   = int(os.getenv("REG_RH",   "0x0002"), 16)  # Holding register for humidity
 
 def read_one(client, unit, addr):
-    r = client.read_input_registers(addr, 1, unit=unit)
-    if r.isError(): raise RuntimeError(str(r))
+    """Read a single holding register from the device.
+
+    The SHT20's Modbus mapping uses the holding-register address space (4xxxx)
+    rather than the input-register space (3xxxx), so we must call
+    ``read_holding_registers`` here.
+    """
+
+    r = client.read_holding_registers(addr, 1, unit=unit)
+    if r.isError():
+        raise RuntimeError(str(r))
     return r.registers[0]
 
 def main():
@@ -32,8 +41,8 @@ def main():
         sys.exit(2)
 
     try:
-        t_raw = read_one(client, SLAVE, REG_TEMP)  # °C × 10
-        h_raw = read_one(client, SLAVE, REG_RH)    # %RH × 10
+        t_raw = read_one(client, SLAVE, REG_TEMP)  # Holding register, °C × 10
+        h_raw = read_one(client, SLAVE, REG_RH)    # Holding register, %RH × 10
         print(f"Temperature: {t_raw/10.0:.1f} °C")
         print(f"Humidity:    {h_raw/10.0:.1f} %RH")
     finally:


### PR DESCRIPTION
## Summary
- use `read_holding_registers` when reading SHT20 sensor values
- document that temperature and humidity live in holding register space

## Testing
- `python -m py_compile tools/sht20_ch4_test.py`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_689f371349908332a388b5004c63460f