### PR TITLE
refactor: rename env var and cleanup

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -10,4 +10,4 @@ Polls an SHT20 sensor via the Waveshare 4‑channel RS485 gateway.
 ```bash
 python sht20_ch4_test.py [--mode rtu|tcp]
 ```
-Defaults to RTU‑over‑TCP. Override connection details with the `GW_CH4_HOST`, `GW_PORT`, `GW_CH4_SLAVES`, `REG_TEMP`, and `REG_RH` environment variables.
+Defaults to RTU‑over‑TCP. Override connection details with the `GW_CH4_HOST`, `GW_PORT`, `SENSOR_ADDRESS`, `REG_TEMP`, and `REG_RH` environment variables.

--- a/tools/sht20_ch4_test.py
+++ b/tools/sht20_ch4_test.py
@@ -1,9 +1,9 @@
-import argparse, os, sys, time
+import argparse, os, sys
 from pymodbus.client import ModbusSerialClient, ModbusTcpClient
 
 HOST = os.getenv("GW_CH4_HOST", "192.168.1.204")
 PORT = int(os.getenv("GW_PORT", "4196"))
-SLAVE = int(os.getenv("GW_CH4_SLAVES", "1"))
+SENSOR_ADDR = int(os.getenv("SENSOR_ADDRESS", "1"))
 REG_TEMP = int(os.getenv("REG_TEMP", "0x0001"), 16)
 REG_RH   = int(os.getenv("REG_RH",   "0x0002"), 16)
 
@@ -32,8 +32,8 @@ def main():
         sys.exit(2)
 
     try:
-        t_raw = read_one(client, SLAVE, REG_TEMP)  # °C × 10
-        h_raw = read_one(client, SLAVE, REG_RH)    # %RH × 10
+        t_raw = read_one(client, SENSOR_ADDR, REG_TEMP)  # °C × 10
+        h_raw = read_one(client, SENSOR_ADDR, REG_RH)    # %RH × 10
         print(f"Temperature: {t_raw/10.0:.1f} °C")
         print(f"Humidity:    {h_raw/10.0:.1f} %RH")
     finally:


### PR DESCRIPTION
## Summary
- drop unused time import
- use SENSOR_ADDRESS env var instead of deprecated GW_CH4_SLAVES

## Testing
- `pytest`
- `python -m py_compile tools/sht20_ch4_test.py`


------
https://chatgpt.com/codex/tasks/task_e_689f37178bd08332a2a8b30ae149d2dc