### PR TITLE
Allow specifying Modbus function codes per sensor

### DIFF
--- a/backend/poller.py
+++ b/backend/poller.py
@@ -13,27 +13,58 @@ TEMPERATURE_REGISTER = 2
 DEFAULT_INTERVAL = 60.0
 
 
-def load_sensor_addresses() -> list[int]:
-    """Collect sensor addresses from environment variables."""
-    addresses: list[int] = []
+def load_sensor_configs() -> dict[int, int]:
+    """Collect sensor addresses and function codes from environment variables.
+
+    Sensors are configured using pairs of environment variables:
+
+    ``SENSOR1_ADDRESS=1`` and ``SENSOR1_FC=4`` for example. If the function
+    code is missing or invalid, function code 3 is assumed.
+
+    Returns:
+        Mapping of sensor address to Modbus function code (3 or 4).
+    """
+
+    configs: dict[int, int] = {}
     for key, value in os.environ.items():
         if key.startswith("SENSOR") and key.endswith("_ADDRESS"):
+            prefix = key[: -len("_ADDRESS")]
             try:
-                addresses.append(int(value))
+                address = int(value)
             except ValueError:
                 logging.warning("Invalid sensor address %s=%s", key, value)
-    return sorted(addresses)
+                continue
+
+            fc_key = f"{prefix}_FC"
+            try:
+                fc = int(os.getenv(fc_key, "3"))
+            except ValueError:
+                logging.warning("Invalid function code %s=%s", fc_key, os.getenv(fc_key))
+                fc = 3
+            if fc not in (3, 4):
+                logging.warning("Unsupported function code %s=%s", fc_key, fc)
+                fc = 3
+            configs[address] = fc
+
+    return dict(sorted(configs.items()))
 
 
-async def read_sensor(client: AsyncModbusTcpClient, address: int) -> None:
+async def read_sensor(
+    client: AsyncModbusTcpClient, address: int, function_code: int
+) -> None:
     """Read and log humidity and temperature for a sensor."""
     if not client.connected:
         logging.error("Modbus client not connected")
         return
     try:
-        result = await client.read_holding_registers(
-            HUMIDITY_REGISTER, 2, slave=address
-        )
+        if function_code == 4:
+            result = await client.read_input_registers(
+                HUMIDITY_REGISTER, 2, slave=address
+            )
+        else:
+            result = await client.read_holding_registers(
+                HUMIDITY_REGISTER, 2, slave=address
+            )
     except Exception as exc:  # pragma: no cover - network failure
         logging.error("Sensor %s read exception: %s", address, exc)
         return
@@ -56,8 +87,8 @@ async def poll_loop(interval: float) -> None:
     load_dotenv()
     host = os.getenv("RS485_GATEWAY_HOST", "localhost")
     port = int(os.getenv("RS485_GATEWAY_PORT", "502"))
-    addresses = load_sensor_addresses()
-    if not addresses:
+    sensor_configs = load_sensor_configs()
+    if not sensor_configs:
         logging.warning("No sensor addresses configured")
         return
 
@@ -67,8 +98,8 @@ async def poll_loop(interval: float) -> None:
                 if not client.connected:
                     logging.error("Modbus client not connected")
                 else:
-                    for address in addresses:
-                        await read_sensor(client, address)
+                    for address, fc in sensor_configs.items():
+                        await read_sensor(client, address, fc)
         except Exception as exc:  # pragma: no cover - network failure
             logging.error("Connection error: %s", exc)
         await asyncio.sleep(interval)


### PR DESCRIPTION
## Summary
- allow sensors to define Modbus function codes via `SENSORn_FC`
- read input or holding registers depending on function code

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1e02c44c4833288295ec250f76ca9