### PR TITLE
Replace deprecated slave argument with unit

### DIFF
--- a/backend/poller.py
+++ b/backend/poller.py
@@ -59,11 +59,11 @@ async def read_sensor(
     try:
         if function_code == 4:
             result = await client.read_input_registers(
-                HUMIDITY_REGISTER, 2, slave=address
+                HUMIDITY_REGISTER, 2, unit=address
             )
         else:
             result = await client.read_holding_registers(
-                HUMIDITY_REGISTER, 2, slave=address
+                HUMIDITY_REGISTER, 2, unit=address
             )
     except Exception as exc:  # pragma: no cover - network failure
         logging.error("Sensor %s read exception: %s", address, exc)


### PR DESCRIPTION
## Summary
- update Modbus read calls to use `unit` instead of deprecated `slave`

## Testing
- `python -m py_compile backend/poller.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1fd2154ac8332acb3e18d31bace23