### PR TITLE
feat: add configurable register scaling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,4 +11,7 @@ SENSOR_ADDRESS=1
 # Sensor addresses (Modbus slave IDs)
 SENSOR1_ADDRESS=1
 SENSOR2_ADDRESS=2
+# Optional scaling factors (e.g., 10 or 100, or "auto")
+# SENSOR1_SCALE=10
+# SENSOR2_SCALE=auto
 # Add more SENSOR<N>_ADDRESS entries as needed

--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ Copy the example environment file and adjust it for your gateway and sensors:
 cp .env.example .env
 ```
 
+Optional per-sensor scaling can be configured using `SENSOR<N>_SCALE` entries in
+the `.env` file. Set `SENSOR1_SCALE=10` to multiply a sensor's raw registers by
+10 before converting to human-readable units, or use `auto` for a simple
+Node-RED-style heuristic.
+
 Then run the backend poller from the repository root to continuously read sensors:
 
 ```bash

--- a/backend/poller.py
+++ b/backend/poller.py
@@ -3,6 +3,7 @@ import asyncio
 import logging
 import os
 import sys
+from dataclasses import dataclass
 from datetime import datetime
 
 from dotenv import load_dotenv
@@ -13,19 +14,28 @@ TEMPERATURE_REGISTER = 2
 DEFAULT_INTERVAL = 60.0
 
 
-def load_sensor_configs() -> dict[int, int]:
-    """Collect sensor addresses and function codes from environment variables.
+@dataclass
+class SensorConfig:
+    """Configuration for a single sensor."""
 
-    Sensors are configured using pairs of environment variables:
+    function_code: int
+    scale: float | str = 1.0
 
-    ``SENSOR1_ADDRESS=1`` and ``SENSOR1_FC=4`` for example. If the function
-    code is missing or invalid, function code 3 is assumed.
+
+def load_sensor_configs() -> dict[int, SensorConfig]:
+    """Collect sensor addresses, function codes, and scales from env vars.
+
+    Sensors are configured using groups of environment variables. For example,
+    ``SENSOR1_ADDRESS=1``, ``SENSOR1_FC=4`` and ``SENSOR1_SCALE=10``. If the
+    function code is missing or invalid, function code 3 is assumed. Scale
+    defaults to ``1`` but can also be set to ``auto`` to enable a simple
+    Node-RED-style auto-scaling heuristic.
 
     Returns:
-        Mapping of sensor address to Modbus function code (3 or 4).
+        Mapping of sensor address to configuration.
     """
 
-    configs: dict[int, int] = {}
+    configs: dict[int, SensorConfig] = {}
     for key, value in os.environ.items():
         if key.startswith("SENSOR") and key.endswith("_ADDRESS"):
             prefix = key[: -len("_ADDRESS")]
@@ -44,13 +54,38 @@ def load_sensor_configs() -> dict[int, int]:
             if fc not in (3, 4):
                 logging.warning("Unsupported function code %s=%s", fc_key, fc)
                 fc = 3
-            configs[address] = fc
+
+            scale_key = f"{prefix}_SCALE"
+            scale_env = os.getenv(scale_key, "1")
+            if scale_env.lower() == "auto":
+                scale: float | str = "auto"
+            else:
+                try:
+                    scale = float(scale_env)
+                except ValueError:
+                    logging.warning("Invalid scale %s=%s", scale_key, scale_env)
+                    scale = 1.0
+
+            configs[address] = SensorConfig(function_code=fc, scale=scale)
 
     return dict(sorted(configs.items()))
 
 
+def _apply_scale(value: int, scale: float | str) -> float:
+    """Scale a raw register using a factor or simple auto heuristic."""
+
+    if scale == "auto":
+        factor = 1.0
+        scaled = value
+        while scaled < 1000 and scaled != 0:
+            factor *= 10
+            scaled = value * factor
+        return scaled
+    return value * float(scale)
+
+
 async def read_sensor(
-    client: AsyncModbusTcpClient, address: int, function_code: int
+    client: AsyncModbusTcpClient, address: int, function_code: int, scale: float | str
 ) -> None:
     """Read and log humidity and temperature for a sensor."""
     if not client.connected:
@@ -72,6 +107,8 @@ async def read_sensor(
         logging.error("Sensor %s read error: %s", address, result)
         return
     humidity_raw, temperature_raw = result.registers
+    humidity_raw = _apply_scale(humidity_raw, scale)
+    temperature_raw = _apply_scale(temperature_raw, scale)
     humidity = -6 + 125 * humidity_raw / 65536.0
     temperature = -46.85 + 175.72 * temperature_raw / 65536.0
     logging.info(
@@ -98,8 +135,8 @@ async def poll_loop(interval: float) -> None:
                 if not client.connected:
                     logging.error("Modbus client not connected")
                 else:
-                    for address, fc in sensor_configs.items():
-                        await read_sensor(client, address, fc)
+                    for address, cfg in sensor_configs.items():
+                        await read_sensor(client, address, cfg.function_code, cfg.scale)
         except Exception as exc:  # pragma: no cover - network failure
             logging.error("Connection error: %s", exc)
         await asyncio.sleep(interval)


### PR DESCRIPTION
## Summary
- allow per-sensor scaling via SENSOR<N>_SCALE env var with optional `auto` heuristic
- apply scaling to raw humidity and temperature registers before conversion
- document new scale configuration in README and example env file

## Testing
- `python -m py_compile backend/poller.py`


------
https://chatgpt.com/codex/tasks/task_e_68a21e3e9af08332ba3776cd559967d8