### PR TITLE
Support multiple RS485 gateways

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,14 +1,23 @@
 # Example environment configuration for the RS485 poller
 # Replace the placeholders with values for your setup
 
-# RS485 gateway connection
-RS485_GATEWAY_HOST=192.0.2.1
-RS485_GATEWAY_PORT=502
+# Gateway 1 connection and sensors
+GW1_HOST=192.0.2.1
+GW1_PORT=502
+GW1_SENSOR1_ADDRESS=1
+GW1_SENSOR2_ADDRESS=2
+# Add more GW1_SENSOR<N>_ADDRESS entries as needed
+
+# Optional second gateway
+#GW2_HOST=192.0.2.2
+#GW2_PORT=502
+#GW2_SENSOR1_ADDRESS=3
 
 # Example sensor address for diagnostic scripts
 SENSOR_ADDRESS=1
 
-# Sensor addresses (Modbus slave IDs)
-SENSOR1_ADDRESS=1
-SENSOR2_ADDRESS=2
-# Add more SENSOR<N>_ADDRESS entries as needed
+# Legacy single-gateway variables are still supported:
+#RS485_GATEWAY_HOST=192.0.2.1
+#RS485_GATEWAY_PORT=502
+#SENSOR1_ADDRESS=1
+#SENSOR2_ADDRESS=2

--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ Copy the example environment file and adjust it for your gateway and sensors:
 cp .env.example .env
 ```
 
+Define `GW1_HOST`/`GW1_PORT` for the first RS485 gateway and
+`GW1_SENSOR<N>_ADDRESS` entries for its sensors. Additional gateways can be
+added with `GW2_HOST`, `GW2_PORT`, and corresponding sensor variables.
+
 Then run the backend poller from the repository root to continuously read sensors:
 
 ```bash

--- a/backend/poller.py
+++ b/backend/poller.py
@@ -3,6 +3,7 @@ import asyncio
 import logging
 import os
 import sys
+from dataclasses import dataclass
 from datetime import datetime
 
 from dotenv import load_dotenv
@@ -13,13 +14,27 @@ TEMPERATURE_REGISTER = 2
 DEFAULT_INTERVAL = 60.0
 
 
-def load_sensor_configs() -> dict[int, int]:
+@dataclass
+class GatewayConfig:
+    """Connection and sensor details for a single gateway."""
+
+    host: str
+    port: int
+    sensors: dict[int, int]
+
+
+def load_sensor_configs(prefix: str = "") -> dict[int, int]:
     """Collect sensor addresses and function codes from environment variables.
 
-    Sensors are configured using pairs of environment variables:
+    Sensors are configured using pairs of environment variables. With no
+    prefix, variables look like ``SENSOR1_ADDRESS=1`` and ``SENSOR1_FC=4``. For
+    gateway‑specific sensors a prefix such as ``GW1_`` is applied, e.g.
+    ``GW1_SENSOR1_ADDRESS``. If the function code is missing or invalid,
+    function code 3 is assumed.
 
-    ``SENSOR1_ADDRESS=1`` and ``SENSOR1_FC=4`` for example. If the function
-    code is missing or invalid, function code 3 is assumed.
+    Args:
+        prefix: Optional prefix for environment variable names, including the
+            trailing underscore (e.g., ``"GW1_"``).
 
     Returns:
         Mapping of sensor address to Modbus function code (3 or 4).
@@ -27,15 +42,21 @@ def load_sensor_configs() -> dict[int, int]:
 
     configs: dict[int, int] = {}
     for key, value in os.environ.items():
-        if key.startswith("SENSOR") and key.endswith("_ADDRESS"):
-            prefix = key[: -len("_ADDRESS")]
+        if prefix:
+            if not key.startswith(prefix):
+                continue
+            key_body = key[len(prefix) :]
+        else:
+            key_body = key
+        if key_body.startswith("SENSOR") and key_body.endswith("_ADDRESS"):
+            sensor_prefix = key_body[: -len("_ADDRESS")]
             try:
                 address = int(value)
             except ValueError:
                 logging.warning("Invalid sensor address %s=%s", key, value)
                 continue
 
-            fc_key = f"{prefix}_FC"
+            fc_key = f"{prefix}{sensor_prefix}_FC"
             try:
                 fc = int(os.getenv(fc_key, "3"))
             except ValueError:
@@ -47,6 +68,43 @@ def load_sensor_configs() -> dict[int, int]:
             configs[address] = fc
 
     return dict(sorted(configs.items()))
+
+
+def load_gateway_configs() -> list[GatewayConfig]:
+    """Collect gateway connection details and their sensors from environment."""
+
+    gateways: list[GatewayConfig] = []
+
+    prefixes: set[str] = set()
+    for key in os.environ:
+        if key.startswith("GW") and key.endswith("_HOST"):
+            prefixes.add(key[: -len("_HOST")])
+
+    for prefix in sorted(prefixes):
+        host = os.getenv(f"{prefix}_HOST", "localhost")
+        try:
+            port = int(os.getenv(f"{prefix}_PORT", "502"))
+        except ValueError:
+            logging.warning("Invalid port for %s", prefix)
+            continue
+        sensors = load_sensor_configs(f"{prefix}_")
+        if not sensors:
+            logging.warning("No sensor addresses configured for %s", prefix)
+        gateways.append(GatewayConfig(host, port, sensors))
+
+    if not gateways:
+        # Fallback to legacy single-gateway configuration
+        host = os.getenv("RS485_GATEWAY_HOST", "localhost")
+        try:
+            port = int(os.getenv("RS485_GATEWAY_PORT", "502"))
+        except ValueError:
+            logging.warning("Invalid RS485 gateway port")
+            return []
+        sensors = load_sensor_configs()
+        if sensors:
+            gateways.append(GatewayConfig(host, port, sensors))
+
+    return gateways
 
 
 async def read_sensor(
@@ -85,23 +143,26 @@ async def read_sensor(
 
 async def poll_loop(interval: float) -> None:
     load_dotenv()
-    host = os.getenv("RS485_GATEWAY_HOST", "localhost")
-    port = int(os.getenv("RS485_GATEWAY_PORT", "502"))
-    sensor_configs = load_sensor_configs()
-    if not sensor_configs:
-        logging.warning("No sensor addresses configured")
+    gateways = load_gateway_configs()
+    if not gateways:
+        logging.warning("No gateways configured")
         return
 
     while True:
-        try:
-            async with AsyncModbusTcpClient(host, port=port) as client:
-                if not client.connected:
-                    logging.error("Modbus client not connected")
-                else:
-                    for address, fc in sensor_configs.items():
-                        await read_sensor(client, address, fc)
-        except Exception as exc:  # pragma: no cover - network failure
-            logging.error("Connection error: %s", exc)
+        for gateway in gateways:
+            try:
+                async with AsyncModbusTcpClient(gateway.host, port=gateway.port) as client:
+                    if not client.connected:
+                        logging.error(
+                            "Modbus client not connected to %s:%s", gateway.host, gateway.port
+                        )
+                    else:
+                        for address, fc in gateway.sensors.items():
+                            await read_sensor(client, address, fc)
+            except Exception as exc:  # pragma: no cover - network failure
+                logging.error(
+                    "Connection error %s:%s %s", gateway.host, gateway.port, exc
+                )
         await asyncio.sleep(interval)
 
 


### PR DESCRIPTION
## Summary
- allow configuring multiple RS485 gateways via `GWn_HOST`/`GWn_PORT`
- iterate over each gateway and poll its configured sensors
- document new environment variables in README and `.env.example`

## Testing
- `python -m py_compile backend/poller.py`


------
https://chatgpt.com/codex/tasks/task_e_68a21e43c1808332baeb1e40e2a9030a