### PR TITLE
Refactor sensor config to attach gateways and infer defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,23 +1,23 @@
 # Example environment configuration for the RS485 poller
 # Replace the placeholders with values for your setup
 
-# Gateway 1 connection and sensors
-GW1_HOST=192.0.2.1
-GW1_PORT=502
-GW1_SENSOR1_ADDRESS=1
-GW1_SENSOR2_ADDRESS=2
-# Add more GW1_SENSOR<N>_ADDRESS entries as needed
+# Gateway connection and sensors
+GW_4XCH1_HOST=192.0.2.1
+GW_4XCH1_PORT=502
+SENSOR1_GATEWAY=4XCH1
+SENSOR1_UNITID=1
+SENSOR1_TYPE=SHT20
+SENSOR2_GATEWAY=4XCH1
+SENSOR2_UNITID=2
+SENSOR2_TYPE=SHT20
+# Add more SENSOR<N> entries as needed
 
 # Optional second gateway
-#GW2_HOST=192.0.2.2
-#GW2_PORT=502
-#GW2_SENSOR1_ADDRESS=3
+#GW_4XCH2_HOST=192.0.2.2
+#GW_4XCH2_PORT=502
+#SENSOR3_GATEWAY=4XCH2
+#SENSOR3_UNITID=3
+#SENSOR3_TYPE=SHT20
 
-# Example sensor address for diagnostic scripts
-SENSOR_ADDRESS=1
-
-# Legacy single-gateway variables are still supported:
-#RS485_GATEWAY_HOST=192.0.2.1
-#RS485_GATEWAY_PORT=502
-#SENSOR1_ADDRESS=1
-#SENSOR2_ADDRESS=2
+# Example sensor unit id for diagnostic scripts
+SENSOR_UNITID=1

--- a/README.md
+++ b/README.md
@@ -69,9 +69,10 @@ Copy the example environment file and adjust it for your gateway and sensors:
 cp .env.example .env
 ```
 
-Define `GW1_HOST`/`GW1_PORT` for the first RS485 gateway and
-`GW1_SENSOR<N>_ADDRESS` entries for its sensors. Additional gateways can be
-added with `GW2_HOST`, `GW2_PORT`, and corresponding sensor variables.e heuristic.
+Define gateway details using `GW_<NAME>_HOST` and `GW_<NAME>_PORT`. Declare
+each sensor with `SENSOR<N>_GATEWAY`, `SENSOR<N>_UNITID`, and
+`SENSOR<N>_TYPE` to associate it with a gateway. Add more sensors by
+incrementing `<N>` and reuse gateway names as needed.
 
 Then run the backend poller from the repository root to continuously read sensors:
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,32 +1,41 @@
 # Backend Environment Configuration
 
-The backend expects gateway and sensor parameters to be supplied via environment variables using these patterns:
+The backend expects gateway and sensor parameters to be supplied via environment
+variables using these patterns:
 
 - `GW_<NAME>_HOST`
 - `GW_<NAME>_PORT`
-- `GW_<NAME>_SENSOR<N>_ADDRESS`
-- `GW_<NAME>_SENSOR<N>_FC`
-- `GW_<NAME>_SENSOR<N>_SCALE`
+- `SENSOR<N>_GATEWAY`
+- `SENSOR<N>_UNITID`
+- `SENSOR<N>_TYPE`
+- `SENSOR<N>_FC` *(optional)*
+- `SENSOR<N>_SCALE` *(optional)*
+- `SENSOR<N>_HUMID_REG` *(optional)*
+- `SENSOR<N>_TEMP_REG` *(optional)*
 
-`<NAME>` identifies a gateway while `<N>` selects a sensor on that gateway.
+`<NAME>` identifies a gateway while `<N>` selects a sensor. Each sensor is
+associated with a gateway via the ``SENSOR<N>_GATEWAY`` variable.
 
 ## Example
 
 ```bash
 GW_4XCH1_HOST=192.168.1.201
 GW_4XCH1_PORT=502
-GW_4XCH1_SENSOR1_ADDRESS=0
-GW_4XCH1_SENSOR1_FC=3
-GW_4XCH1_SENSOR1_SCALE=1
-GW_4XCH1_SENSOR2_ADDRESS=2
-GW_4XCH1_SENSOR2_FC=3
-GW_4XCH1_SENSOR2_SCALE=1
-GW_4XCH1_SENSOR3_ADDRESS=4
-GW_4XCH1_SENSOR3_FC=3
-GW_4XCH1_SENSOR3_SCALE=1
-GW_4XCH1_SENSOR4_ADDRESS=6
-GW_4XCH1_SENSOR4_FC=3
-GW_4XCH1_SENSOR4_SCALE=1
+SENSOR1_GATEWAY=4XCH1
+SENSOR1_UNITID=1
+SENSOR1_TYPE=SHT20
+SENSOR2_GATEWAY=4XCH1
+SENSOR2_UNITID=2
+SENSOR2_TYPE=SHT20
+SENSOR3_GATEWAY=4XCH1
+SENSOR3_UNITID=3
+SENSOR3_TYPE=SHT20
+SENSOR4_GATEWAY=4XCH1
+SENSOR4_UNITID=4
+SENSOR4_TYPE=SHT20
 ```
 
-This example mirrors the typical mapping for a four channel gateway.
+This example mirrors the typical mapping for a four channel gateway. Function
+codes and register addresses are inferred from ``SENSOR_TYPES`` based on the
+``SENSOR<N>_TYPE`` values but may be overridden by providing the optional
+variables shown above.


### PR DESCRIPTION
## Summary
- group sensor environment variables by gateway via `SENSORn_GATEWAY`
- auto-fill sensor Modbus parameters using `SENSOR_TYPES`
- document new gateway/sensor configuration patterns and update examples

## Testing
- `python -m py_compile backend/poller.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a22bbde7988332a7a0ec9bb6596f95