### PR TITLE
Adjust SHT sensor defaults

### DIFF
--- a/backend/poller.py
+++ b/backend/poller.py
@@ -12,12 +12,12 @@ from pymodbus.client import AsyncModbusTcpClient
 SENSOR_TYPES = {
     "SHT20": {
         "function_code": 4,
-        "humidity_register": 1,
-        "temperature_register": 2,
+        "humidity_register": 2,
+        "temperature_register": 1,
         "serial": {"baudrate": 9600, "parity": "N", "stopbits": 1},
     },
     "SHT30": {
-        "function_code": 4,
+        "function_code": 3,
         "humidity_register": 1,
         "temperature_register": 0,
         "serial": {"baudrate": 9600, "parity": "N", "stopbits": 1},


### PR DESCRIPTION
## Summary
- swap SHT20 humidity/temperature registers
- set SHT30 function code to 3

## Testing
- `python -m py_compile backend/poller.py backend/add_sensor.py`
- `python -m pytest`
- `printf 'SHT20\n4XCH1\n1\n\n\n' | python backend/add_sensor.py`
- `python - <<'PY'\nfrom dotenv import load_dotenv\nfrom backend.poller import load_sensor_configs\nload_dotenv('.env')\nprint(load_sensor_configs())\nPY`
- `printf 'SHT30\n4XCH1\n1\n\n\n' | python backend/add_sensor.py`
- `python - <<'PY'\nfrom dotenv import load_dotenv\nfrom backend.poller import load_sensor_configs\nload_dotenv('.env')\nprint(load_sensor_configs())\nPY`


------
https://chatgpt.com/codex/tasks/task_e_68a25f835a10833281f36fe36871eaca