### PR TITLE
feat: add scaled conversion option

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -14,6 +14,7 @@ variables using these patterns:
 - `SENSOR<N>_TYPE`
 - `SENSOR<N>_FC` *(optional)*
 - `SENSOR<N>_SCALE` *(optional)*
+- `SENSOR<N>_CONVERSION` *(optional, "sht_formula" or "scaled")*
 - `SENSOR<N>_HUMID_REG` *(optional)*
 - `SENSOR<N>_TEMP_REG` *(optional)*
 
@@ -46,7 +47,10 @@ SENSOR4_TYPE=SHT20
 This example mirrors the typical mapping for a four channel gateway. Function
 codes and register addresses are inferred from ``SENSOR_TYPES`` based on the
 ``SENSOR<N>_TYPE`` values but may be overridden by providing the optional
-variables shown above.
+variables shown above. ``SENSOR<N>_CONVERSION`` controls whether raw register
+values are interpreted using the Sensirion formula (``"sht_formula"``) or as
+already scaled readings (``"scaled"``). Sensors ``SHT20`` and ``SHT30`` default
+to the ``"scaled"`` mode.
 
 ## Adding sensors interactively
 

--- a/backend/add_sensor.py
+++ b/backend/add_sensor.py
@@ -70,6 +70,7 @@ def main() -> None:
     fc = defaults["function_code"]
     humid_reg = defaults["humidity_register"]
     temp_reg = defaults["temperature_register"]
+    conversion = "scaled" if sensor_type in {"SHT20", "SHT30"} else "sht_formula"
 
     sensor_number = _next_sensor_number(env)
 
@@ -90,6 +91,7 @@ def main() -> None:
             f"{prefix}_UNITID={unit_id}\n",
             f"{prefix}_TYPE={sensor_type}\n",
             f"{prefix}_FC={fc}\n",
+            f"{prefix}_CONVERSION={conversion}\n",
             f"{prefix}_HUMID_REG={humid_reg}\n",
             f"{prefix}_TEMP_REG={temp_reg}\n",
         ]


### PR DESCRIPTION
## Summary
- add conversion strategy field to sensor configuration
- support scaled conversion to bypass SHT formula
- document and expose conversion setting in helper script and README

## Testing
- `python -m py_compile backend/poller.py backend/add_sensor.py`


------
https://chatgpt.com/codex/tasks/task_e_68a27b67d53883328b90fe9274272420