### PR TITLE
Add device nickname and channel-aware logging

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -12,6 +12,7 @@ variables using these patterns:
 - `SENSOR<N>_GATEWAY`
 - `SENSOR<N>_UNITID`
 - `SENSOR<N>_TYPE`
+- `SENSOR<N>_DEVID` *(optional, defaults to the sensor prefix)*
 - `SENSOR<N>_FC` *(optional)*
 - `SENSOR<N>_SCALE` *(optional)*
 - `SENSOR<N>_CONVERSION` *(optional, "sht_formula" or "scaled")*


### PR DESCRIPTION
## Summary
- support sensor nicknames via `SENSOR<N>_DEVID` and propagate to SensorConfig
- track gateway names in GatewayConfig and pass channel to `read_sensor`
- include device and channel info in sensor logs for easier debugging

## Testing
- `python -m py_compile backend/poller.py`


------
https://chatgpt.com/codex/tasks/task_e_68a283dd609483328329d3deeae5ad08