### PR TITLE
Add Firestore publishing

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,4 @@
 pymodbus>=3.5
 python-dotenv>=1.0
+google-cloud-firestore>=2.21
 # Additional libraries will be added as features expand (e.g., logging, CLI, database)


### PR DESCRIPTION
## Summary
- init Firestore AsyncClient configured from env
- add helper to publish sensor readings
- log readings to Firestore and update requirements

## Testing
- `python -m py_compile backend/poller.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a28f6eadb883329080406b671c91bd