### PR TITLE
Add Firestore dependency to backend requirements

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,5 @@
 pymodbus>=3.5
 python-dotenv>=1.0
 google-cloud-firestore>=2.21
+google-cloud-firestore>=2.0
 # Additional libraries will be added as features expand (e.g., logging, CLI, database)


### PR DESCRIPTION
## Summary
- append google-cloud-firestore dependency to backend requirements

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2904e62c483328a43f8a79c991226