### PR TITLE
Add Firestore environment configuration placeholders

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,12 @@
 # Example environment configuration for the RS485 poller
 # Replace the placeholders with values for your setup
 
+# Firestore
+FIRESTORE_PROJECT=your-project-id
+FIRESTORE_COLLECTION=your-collection-name
+# Path to your service account key JSON file
+GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account-key.json
+
 # Gateway Connections
 #   Channel 1
       GW_4XCH1_HOST=192.168.1.201

--- a/backend/README.md
+++ b/backend/README.md
@@ -22,6 +22,22 @@ variables using these patterns:
 `<NAME>` identifies a gateway while `<N>` selects a sensor. Each sensor is
 associated with a gateway via the ``SENSOR<N>_GATEWAY`` variable.
 
+## Firestore configuration
+
+Readings may be stored in Google Cloud Firestore. Supply the connection
+information via the following environment variables, either in your ``.env``
+file or directly in the shell:
+
+```bash
+FIRESTORE_PROJECT=your-project-id
+FIRESTORE_COLLECTION=your-collection-name
+GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account-key.json
+```
+
+The ``GOOGLE_APPLICATION_CREDENTIALS`` value must point to a service account
+key JSON file with permission to access Firestore. You can create and download
+this key from the Google Cloud Console under **IAM & Admin → Service Accounts**.
+
 ## Example
 
 ```bash


### PR DESCRIPTION
## Summary
- add Firestore and service account variables to `.env.example`
- document how to configure Firestore credentials in backend README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a291fd6c6483328a5b7a4af6e264d2