### PR TITLE
feat: add debug flag to poller

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -45,6 +45,12 @@ Temperatures are logged and published in Celsius by default. Set
 
     DEGREES_F=1
 
+## Debug logging
+
+Enable verbose output by passing the ``--debug`` flag::
+
+    python backend/poller.py --debug
+
 ## Example
 
 ```bash

--- a/backend/poller.py
+++ b/backend/poller.py
@@ -443,12 +443,19 @@ def parse_args() -> argparse.Namespace:
         default=DEFAULT_INTERVAL,
         help="Polling interval in seconds (default: %(default)s)",
     )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Enable debug logging",
+    )
     return parser.parse_args()
 
 
 def main() -> None:
     args = parse_args()
-    logging.basicConfig(level=logging.INFO, stream=sys.stdout)
+    logging.basicConfig(
+        level=logging.DEBUG if args.debug else logging.INFO, stream=sys.stdout
+    )
     try:
         asyncio.run(poll_loop(args.interval))
     except KeyboardInterrupt:


### PR DESCRIPTION
## Summary
- allow enabling verbose logging in poller with a new `--debug` flag
- document the `--debug` option in backend README

## Testing
- `python -m py_compile backend/poller.py`
- `python backend/poller.py --help`

------
https://chatgpt.com/codex/tasks/task_e_68a1d05e4c04833290c8cdfd668d2df7