### PR TITLE
Use gpiod for display GPIO control

### DIFF
--- a/display/requirements.txt
+++ b/display/requirements.txt
@@ -3,3 +3,4 @@ adafruit-circuitpython-ili9341
 spidev
 evdev
 pillow
+gpiod


### PR DESCRIPTION
## Summary
- import python-gpiod and configure display pins via libgpiod
- pass requested GPIO lines into st7789 driver for raw control
- document gpiod dependency for display tests

## Testing
- `python -m py_compile display/display_test.py`
- `GPGC_SKIP_DISPLAY=1 python display/display_test.py --width 240 --height 320 --rotation 180`


------
https://chatgpt.com/codex/tasks/task_e_68a531b32ec483328dc2aea30d6cf92e