### PR TITLE
Remove ILI9341 fallback for display tests

### DIFF
--- a/display/display_test.py
+++ b/display/display_test.py
@@ -15,11 +15,7 @@ import time
 from PIL import Image, ImageDraw, ImageFont
 import gpiod
 import spidev
-
-try:
-    import st7789
-except ImportError:  # pragma: no cover - fallback for different panels
-    from adafruit_ili9341 import ILI9341 as st7789  # type: ignore
+import st7789
 
 
 SPI_BUS = 0

--- a/display/requirements.txt
+++ b/display/requirements.txt
@@ -1,5 +1,4 @@
 st7789
-adafruit-circuitpython-ili9341
 spidev
 evdev
 pillow


### PR DESCRIPTION
## Summary
- Drop ILI9341 fallback and import ST7789 directly
- Remove adafruit-circuitpython-ili9341 from display requirements

## Testing
- `python -m py_compile display/display_test.py`
- `pip install -r display/requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68a533cc983883329b19db48a47664dd