### PR TITLE
Use Luckfox Pico Ultra GPIO offsets in display test

### DIFF
--- a/display/display_test.py
+++ b/display/display_test.py
@@ -30,9 +30,13 @@ DEFAULT_WIDTH = 240
 DEFAULT_HEIGHT = 320
 DEFAULT_ROTATION = 180
 
-DC_PIN = 24
-RST_PIN = 23
-BACKLIGHT_PIN = 25
+# Luckfox Pico Ultra GPIO offsets mapping:
+# - GPIO2_A7_d (DC)
+# - GPIO1_D3_d (Reset)
+# - GPIO2_A6_d (Backlight)
+DC_PIN = 71  # GPIO2_A7_d
+RST_PIN = 59  # GPIO1_D3_d
+BACKLIGHT_PIN = 70  # GPIO2_A6_d
 
 
 def init_display(width: int, height: int, rotation: int) -> "st7789.ST7789 | None":


### PR DESCRIPTION
## Summary
- map Luckfox Pico Ultra GPIO lines to display test pins
- use the mapped offsets when configuring gpiod lines

## Testing
- `python -m py_compile display/display_test.py && echo "py_compile success"`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a533a7aa548332a0da0d7ddde34b1f