### PR TITLE
Allow BME688 reader to select I2C bus

### DIFF
--- a/sensor/read_bme688.py
+++ b/sensor/read_bme688.py
@@ -1,16 +1,23 @@
+import argparse
 import time
+
 import bme680
 from smbus2 import SMBus
 
 
-def main() -> None:
+DEFAULT_BUS = 2
+
+
+def main(bus: int = DEFAULT_BUS) -> None:
     """Poll BME688 sensor and log readings every second."""
     try:
         sensor = bme680.BME680(
-            i2c_addr=bme680.I2C_ADDR_SECONDARY, i2c_device=SMBus(2)
+            i2c_addr=bme680.I2C_ADDR_SECONDARY, i2c_device=SMBus(bus)
         )
     except FileNotFoundError as exc:
-        raise RuntimeError("I2C device not found. Adjust bus number if necessary.") from exc
+        raise RuntimeError(
+            f"I2C device on bus {bus} not found. Adjust bus number if necessary."
+        ) from exc
 
     sensor.set_humidity_oversample(bme680.OS_2X)
     sensor.set_pressure_oversample(bme680.OS_4X)
@@ -36,7 +43,12 @@ def main() -> None:
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Poll BME688 sensor")
+    parser.add_argument(
+        "--bus", type=int, default=DEFAULT_BUS, help="I2C bus number"
+    )
+    args = parser.parse_args()
     try:
-        main()
+        main(args.bus)
     except Exception as exc:  # pylint: disable=broad-except
         print(f"Error: {exc}")


### PR DESCRIPTION
## Summary
- default BME688 sensor script to I2C bus 2
- add `--bus` CLI flag to adjust bus number

## Testing
- `python sensor/read_bme688.py` *(fails: I2C device on bus 2 not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a53ec1dc208332a9a4331f7dabb316